### PR TITLE
replace misc.callbacks with callbacks

### DIFF
--- a/website/pages/help/documentationPage.hbs
+++ b/website/pages/help/documentationPage.hbs
@@ -884,7 +884,7 @@ myPie.redraw();
 	<th colspan="4">Callbacks</th>
 </tr>
 <tr>
-	<td>misc.callbacks.onload</td>
+	<td>callbacks.onload</td>
 	<td><span class="label label-green">function</span></td>
 	<td>null</td>
 	<td>
@@ -893,7 +893,7 @@ myPie.redraw();
 	</td>
 </tr>
 <tr>
-	<td>misc.callbacks.onMouseoverSegment</td>
+	<td>callbacks.onMouseoverSegment</td>
 	<td><span class="label label-green">function</span></td>
 	<td>null</td>
 	<td>
@@ -903,15 +903,15 @@ myPie.redraw();
 	</td>
 </tr>
 <tr>
-	<td>misc.callbacks.onMouseoutSegment</td>
+	<td>callbacks.onMouseoutSegment</td>
 	<td><span class="label label-green">function</span></td>
 	<td>null</td>
 	<td>
-		The counterpart of the <code>misc.callbacks.onMouseover</code> callback. It's passed the same info.
+		The counterpart of the <code>callbacks.onMouseover</code> callback. It's passed the same info.
 	</td>
 </tr>
 <tr>
-	<td>misc.callbacks.onClickSegment</td>
+	<td>callbacks.onClickSegment</td>
 	<td><span class="label label-green">function</span></td>
 	<td>null</td>
 	<td>


### PR DESCRIPTION
The documentation says that callbacks should be defined within misc, but in using d3pie and looking at examples, it appears to be outside of misc.
