### PR TITLE
To add arbitrarily formatted string of {value}.

### DIFF
--- a/d3pie-source/_tooltips.js
+++ b/d3pie-source/_tooltips.js
@@ -36,6 +36,7 @@ var tt = {
           return tt.replacePlaceholders(caption, {
             label: d.label,
             value: d.value,
+            f_value: d.f_value,
             percentage: segments.getPercentage(pie, i)
           });
         });


### PR DESCRIPTION
Hi Ben,

Thanks for the library. 

Currently, there is no easy way to add formatted value, i.e `1000.123 -> $1,000.12`, except for using `{caption}`. However, that means that I may not be able to display the percentages in the tooltip. `{f_value}` basically accepts any arbitrary values/strings for now. 
Hence, instead of:

``` javascript
"string": "{label}: {value}, {percentage}%"
```

one can use:

``` javascript
"string": "{label}: {f_value}, {percentage}%"
```

Further consideration can be put in place to make use of [Numeral-js](https://github.com/adamwdraper/Numeral-js). Currently, I am using both libraries independently:

``` javascript
datapoint.f_value = numeral(value).format('$0,0.00');
```

The concept is similar to what Google Charts API has on displaying a formatted value, i.e. ArrowFormat example in [Google Docs API - Formatters](https://developers.google.com/chart/interactive/docs/reference#formatters).

Thanks once again.

Robert
