### PR TITLE
Updated svg block to be responsive

### DIFF
--- a/d3pie-source/_helpers.js
+++ b/d3pie-source/_helpers.js
@@ -10,7 +10,9 @@ var helpers = {
 
 		var svg = d3.select(element).append("svg:svg")
 			.attr("width", canvasWidth)
-			.attr("height", canvasHeight);
+			.attr("height", canvasHeight)
+			.attr("preserveAspectRatio", "xMinYMin meet")
+			.attr("viewBox", "0 0 " + canvasWidth + " " + canvasHeight);
 
 		if (backgroundColor !== "transparent") {
 			svg.style("background-color", function() { return backgroundColor; });


### PR DESCRIPTION
After implementing the d3pie plugin we found that on smaller screens the pie graph was cut off. I have added the attributes preserveAspectRatio and viewBox to the SVG element to allow for the pie graph to be responsive and resize accordingly.