### PR TITLE
Tooltip hover on load fix

### DIFF
--- a/d3pie/d3pie.js
+++ b/d3pie/d3pie.js
@@ -1340,12 +1340,12 @@ var segments = {
 				}
 				return color;
 			})
+			.attr("data-index", function(d, i) { return i; })
 			.style("stroke", segmentStroke)
 			.style("stroke-width", 1)
 			.transition()
 			.ease(d3.easeCubicInOut)
 			.duration(loadSpeed)
-			.attr("data-index", function(d, i) { return i; })
 			.attrTween("d", function(b) {
 				var i = d3.interpolate({ value: 0 }, b);
 				return function(t) {


### PR DESCRIPTION
Quickly hovering over the chart during chart creation (on load) results in console errors due to the data attribute "index" having float instead of integer values, resulting in an invalid selector. I suspect this is due one of the previous function calls asynchronously slowing the call to set the index data attribute. Moving it before the other function calls fixes the issue.