### PR TITLE
hide console warning messages for zero values

### DIFF
--- a/d3pie-source/_validate.js
+++ b/d3pie-source/_validate.js
@@ -42,8 +42,11 @@ var validate = {
 				console.log("not valid: ", options.data.content[i]);
 				continue;
 			}
-			if (options.data.content[i].value <= 0) {
-				console.log("not valid - should have positive value: ", options.data.content[i]);
+			if (options.data.content[i].value < 0) {
+				console.log("not valid - should have non negative value: ", options.data.content[i]);
+				continue;
+			}
+			if (options.data.content[i].value = 0) {
 				continue;
 			}
 			data.push(options.data.content[i]);


### PR DESCRIPTION
Zero values are not showed on the pie, so I would like to avoid warning messages on the console like this:

<kbd>![image](https://user-images.githubusercontent.com/1625334/41356115-72f24772-6f23-11e8-9c00-0deba2d119d9.png)</kbd>
