### PR TITLE
Fix the validation on the final item to ensure the percentage always adds up to precisely 100%.

### DIFF
--- a/d3pie/d3pie.js
+++ b/d3pie/d3pie.js
@@ -2025,18 +2025,91 @@ var tt = {
 
         var dp = this.options.labels.percentage.decimalPlaces;
 
-        // add in percentage data to content
-        for (var i=0; i<this.options.data.content.length; i++) {
-            this.options.data.content[i].percentage = _getPercentage(this.options.data.content[i].value, this.totalSize, dp);
-        }
+		var roundedPer = [];
+		var exactPer = [];
+		
+		for (var i = 0; i < this.options.data.content.length; i++) {
+			this.options.data.content[i].percentage = _getPercentage(Math.floor(this.options.data.content[i].value), this.totalSize, dp);
+			roundedPer.push(this.options.data.content[i].percentage);
+			exactPer.push(_getExactPercentage(Math.floor(this.options.data.content[i].value), this.totalSize));
 
-        // adjust the final item to ensure the percentage always adds up to precisely 100%. This is necessary
+		}
+
+		 // adjust the final item to ensure the percentage always adds up to precisely 100%. This is necessary 
 		var totalPercentage = 0;
-        for (var j=0; j<this.options.data.content.length; j++) {
-        	if (j === this.options.data.content.length - 1) {
-                this.options.data.content[j].percentage = (100 - totalPercentage).toFixed(dp);
+		var i;
+		while (totalPercentage != 100) {
+			var totalPercentage = 0;
+			for (i = 0; i < roundedPer.length; i++) {
+				totalPercentage += roundedPer[i];
 			}
-			totalPercentage += parseFloat(this.options.data.content[j].percentage);
+
+			if (totalPercentage > 100) {
+
+				var minFrac;
+				var minIndex = -1;
+				var frac;
+				var j = 0;
+				while (j != -1) {
+					frac = exactPer[j] - Math.floor(exactPer[j]);
+					if ((Math.round(exactPer[j]) - Math.floor(exactPer[j])) != 0) {
+						minFrac = frac;
+						minIndex = j;
+						j = -1;
+					}
+					else {
+						j++;
+					}
+				}
+
+				for (j = 0; j < exactPer.length; j++) {
+					frac = exactPer[j] - Math.floor(exactPer[j]);
+					if ((Math.round(exactPer[j]) - Math.floor(exactPer[j])) != 0 && frac < minFrac) {
+						minFrac = frac;
+						minIndex = j;
+					}
+				}
+				if (minIndex != -1) {
+					roundedPer[minIndex] = Math.floor(exactPer[minIndex]);
+					exactPer[minIndex] = roundedPer[minIndex];
+				}
+			} else if (totalPercentage < 100) {
+
+				var maxFrac;
+				var maxIndex = -1;
+				var frac;
+				var j = 0;
+				while (j != -1) {
+					frac = exactPer[j] - Math.floor(exactPer[j]);
+					if ((Math.round(exactPer[j]) - Math.floor(exactPer[j])) == 0) {
+						maxFrac = frac;
+						maxIndex = j;
+						j = -1;
+					}
+					else {
+						j++;
+					}
+				}
+
+				for (j = 0; j < exactPer.length; j++) {
+					frac = exactPer[j] - Math.floor(exactPer[j]);
+					if ((Math.round(exactPer[j]) - Math.floor(exactPer[j])) == 0 && frac > maxFrac) {
+						maxFrac = frac;
+						maxIndex = j;
+					}
+				}
+				if (maxIndex != -1) {
+					roundedPer[maxIndex] = Math.ceil(exactPer[maxIndex]);
+					exactPer[maxIndex] = roundedPer[maxIndex];
+				}
+			}
+			else {
+
+			}
+		}
+
+        for (var j=0; j<this.options.data.content.length; j++) {
+			this.options.data.content[j].percentage = roundedPer[j];
         }
 	};
 
@@ -2173,5 +2246,8 @@ var tt = {
 		}
 	};
 
+	var _getExactPercentage = function (value, total) {
+		return (value/total)*100;
+	};
     return d3pie;
 }));


### PR DESCRIPTION
In the validation function on the final item to ensure the percentage always adds up to precisely 100%, it always takes the last segment regardless of its value. For example, when the total percentage is equal to 101% and the last segment is 0%, it will subtract the 1% from 0% and the result become -1%. Another example when the total percentage is equal to 99% and the two last segments both 0%, it will add 1% to the last segment (0%), now the percentages of the last two segments are different (0% and 1%) even the actual value is the same for both (0). The optimal way is to find the optimal segment (not the last segment in every time), and make Math.ceil or Math.floor instead of Math.round depending on the case (>100 or <100) for the optimal segment chosen. Which it is the same method followed in Excel pie graphs. 

To understand how to choose the optimal segment, in this example, we have four rows of data: 

Values [48,17,7,0], Total: 72

Percentage    |   Math.round(Percentage)

66.666        |   67%
23.611        |   24%
9.722          |   10%
0.000          |   0%

The total percentage is **101%**. So, we need to determine the optimal segment to re-calculate its percentage using Math.floor to reduce the total percentage to 100%.
So, we need to make a set of percentages that its fraction >= .5, which Math.round(Percentage) rounds the percentage up to the next largest integer. In this case the set become [66.666, 23.661, 9.722]. The next step is to find the most appropriate percentage for this case, which it's the percentage with minimum fraction in the set [23.611]. 
Re-calculate the percentage: Math.floor(23.611) = 23%.
**Now these are the final percentages with total equals to 100%: [67%, 23%, 10%, 0%].**

Here is another example of another case, in this example, we have four rows of data: 

Values [79,77,30,0], Total: 186

Percentage    |   Math.round(Percentage)

42.473        |   42%
41.397        |   41%
16.129        |   16%
0.000          |   0%

The total percentage is **99%**. So, we need to determine the optimal segment to re-calculate its percentage using Math.ceil to increase the total percentage to 100%.
So, we need to make a set of percentages that its fraction < .5, which Math.round(Percentage) return a value equal to the given percentage. In this case the set become [42.473, 41.397, 16.129, 0.000]. The next step is to find the most appropriate percentage for this case, which it is the percentage with maximum fraction in the set [42.473]. 
Re-calculate the percentage: Math.ceil(42.473) = 43%.
**Now these are the final percentages with total equals to 100%: [43%, 41%, 16%, 0%].**

Thank you.
Shaden